### PR TITLE
Fix component showcase snapshots with mocked random

### DIFF
--- a/src/pages/__tests__/__snapshots__/ComponentShowcase.test.tsx.snap
+++ b/src/pages/__tests__/__snapshots__/ComponentShowcase.test.tsx.snap
@@ -145,24 +145,24 @@ exports[`ComponentShowcase > renders and matches snapshot 1`] = `
               <style>
                 
       @media (max-width: 480px) {
-        .responsive-grid-nxm4m6c5x {
+        .responsive-grid-3tkmm1l27 {
           --grid-columns: repeat(1, 1fr);
         }
       }
       @media (min-width: 480px) and (max-width: 768px) {
-        .responsive-grid-nxm4m6c5x {
+        .responsive-grid-3tkmm1l27 {
           --grid-columns: repeat(2, 1fr);
         }
       }
       @media (min-width: 768px) {
-        .responsive-grid-nxm4m6c5x {
+        .responsive-grid-3tkmm1l27 {
           --grid-columns: repeat(3, 1fr);
         }
       }
     
               </style>
               <div
-                class="responsive-grid-nxm4m6c5x "
+                class="responsive-grid-3tkmm1l27 "
                 style="display: grid; grid-template-columns: var(--grid-columns); gap: 16px; align-items: stretch; justify-items: stretch; width: 100%;"
               >
                 <div


### PR DESCRIPTION
Implement deterministic randomness for tests to stabilize component showcase snapshots.

Component showcase snapshots were failing due to non-deterministic classnames generated by `Math.random` and `crypto.getRandomValues`. This change stubs these global functions with a seeded pseudo-random number generator, ensuring consistent output for snapshot tests.

---
<a href="https://cursor.com/background-agent?bcId=bc-dd590137-4d44-42b8-b632-76aa1ded1431">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dd590137-4d44-42b8-b632-76aa1ded1431">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

