### PR TITLE
Fix inconsistent hook order in SkillTreePage

### DIFF
--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -20,6 +20,15 @@ export const Grid: React.FC<GridProps> = ({
   className = '',
   style,
 }) => {
+  const stableHash = (input: string) => {
+    let hash = 0;
+    for (let i = 0; i < input.length; i++) {
+      hash = (hash << 5) - hash + input.charCodeAt(i);
+      hash |= 0;
+    }
+    return Math.abs(hash).toString(36);
+  };
+
   const getColumns = () => {
     if (typeof columns === 'number') {
       return `repeat(${columns}, 1fr)`;
@@ -41,7 +50,7 @@ export const Grid: React.FC<GridProps> = ({
 
   // Add responsive column styles if columns is an object
   if (typeof columns === 'object') {
-    const gridId = `responsive-grid-${Math.random().toString(36).substr(2, 9)}`;
+    const gridId = `responsive-grid-${stableHash(JSON.stringify(columns))}`;
     const responsiveStyles = `
       @media (max-width: ${breakpoints.mobile}) {
         .${gridId} {
@@ -93,6 +102,15 @@ export const GridItem: React.FC<GridItemProps> = ({
   className = '',
   style,
 }) => {
+  const stableHash = (input: string) => {
+    let hash = 0;
+    for (let i = 0; i < input.length; i++) {
+      hash = (hash << 5) - hash + input.charCodeAt(i);
+      hash |= 0;
+    }
+    return Math.abs(hash).toString(36);
+  };
+
   const getSpan = () => {
     if (typeof span === 'number') {
       return span;
@@ -108,7 +126,7 @@ export const GridItem: React.FC<GridItemProps> = ({
 
   // Add responsive span styles if span is an object
   if (typeof span === 'object') {
-    const itemId = `responsive-grid-item-${Math.random().toString(36).substr(2, 9)}`;
+    const itemId = `responsive-grid-item-${stableHash(JSON.stringify(span))}`;
     const responsiveStyles = `
       @media (max-width: ${breakpoints.mobile}) {
         .${itemId} {

--- a/src/pages/SkillTreePage.tsx
+++ b/src/pages/SkillTreePage.tsx
@@ -16,6 +16,12 @@ export const SkillTreePage: React.FC = () => {
   const units = getAllUnits();
   const completedLessonIds = getCompletedLessonIds();
 
+  useEffect(() => {
+    if (!user) {
+      navigate('/onboarding', { replace: true });
+    }
+  }, [user, navigate]);
+
   const getLessonStatus = (lesson: Lesson) => {
     if (completedLessonIds.includes(lesson.id)) {
       return 'completed';
@@ -33,17 +39,17 @@ export const SkillTreePage: React.FC = () => {
     }
   };
 
-  if (!user) {
-    navigate('/onboarding');
-    return null;
-  }
-
   useEffect(() => {
+    if (!user) return;
     analytics.trackEvent('map_loaded', {
       unitsCount: units.length,
       completedLessons: completedLessonIds.length,
     });
-  }, [units.length, completedLessonIds.length]);
+  }, [user, units.length, completedLessonIds.length]);
+
+  if (!user) {
+    return null;
+  }
 
   return (
     <div

--- a/src/pages/__tests__/__snapshots__/ComponentShowcase.test.tsx.snap
+++ b/src/pages/__tests__/__snapshots__/ComponentShowcase.test.tsx.snap
@@ -145,24 +145,24 @@ exports[`ComponentShowcase > renders and matches snapshot 1`] = `
               <style>
                 
       @media (max-width: 480px) {
-        .responsive-grid-nxm4m6c5x {
+        .responsive-grid-s9yhkq {
           --grid-columns: repeat(1, 1fr);
         }
       }
       @media (min-width: 480px) and (max-width: 768px) {
-        .responsive-grid-nxm4m6c5x {
+        .responsive-grid-s9yhkq {
           --grid-columns: repeat(2, 1fr);
         }
       }
       @media (min-width: 768px) {
-        .responsive-grid-nxm4m6c5x {
+        .responsive-grid-s9yhkq {
           --grid-columns: repeat(3, 1fr);
         }
       }
     
               </style>
               <div
-                class="responsive-grid-nxm4m6c5x "
+                class="responsive-grid-s9yhkq "
                 style="display: grid; grid-template-columns: var(--grid-columns); gap: 16px; align-items: stretch; justify-items: stretch; width: 100%;"
               >
                 <div


### PR DESCRIPTION
Fix React hook order error in `SkillTreePage` and stabilize `Grid` component's class names for consistent snapshots.

The `SkillTreePage` hook order error ('Rendered more hooks than during the previous render') was resolved by moving the conditional onboarding redirect into a `useEffect`, ensuring all hooks are called unconditionally. Additionally, `Grid` component's responsive class names were made deterministic by using a stable hash of props instead of `Math.random`, which fixed flaky snapshot tests.

---
<a href="https://cursor.com/background-agent?bcId=bc-d69a5a47-b879-477d-b192-42a8eb80f45d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d69a5a47-b879-477d-b192-42a8eb80f45d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

