### PR TITLE
Fix lesson mins and pts

### DIFF
--- a/src/pages/SkillTreePage.tsx
+++ b/src/pages/SkillTreePage.tsx
@@ -506,14 +506,15 @@ export const SkillTreePage: React.FC = () => {
                           }}
                         >
                           <div style={{ display: 'flex', gap: spacing.sm }}>
+                            {/* Lesson duration & points with sensible fallbacks to avoid undefined */}
                             <Chip
-                              label={`${lesson.durationMinutes} min`}
+                              label={`${(lesson as any).durationMinutes ?? (lesson.type === 'song' ? 5 : lesson.type === 'practice' ? 4 : 3)} min`}
                               size="small"
                               variant="outlined"
                               icon={<Icon name="schedule" size={14} />}
                             />
                             <Chip
-                              label={`${lesson.points} pts`}
+                              label={`${(lesson as any).points ?? lesson.level * 5} pts`}
                               size="small"
                               variant="outlined"
                               color="secondary"


### PR DESCRIPTION
Provide default values for lesson duration and points to prevent "undefined min" and "undefined pts" messages.

---
<a href="https://cursor.com/background-agent?bcId=bc-c50b5e58-a1bc-408e-88cf-e14082ae75fc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c50b5e58-a1bc-408e-88cf-e14082ae75fc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

